### PR TITLE
pre-release changes for identity cookie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11137,16 +11137,13 @@
     },
     "packages/sdk-akamai": {
       "name": "@adobe/target-cdn-experimentation-akamai-sdk",
-      "version": "0.0.2",
+      "version": "0.0.5",
       "license": "Apache-2.0"
     },
     "packages/sdk-nodejs": {
       "name": "@adobe/target-cdn-experimentation-nodejs-sdk",
-      "version": "0.0.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@adobe/target-cdn-experimentation-core": "^0.0.1"
-      }
+      "version": "0.0.5",
+      "license": "Apache-2.0"
     }
   }
 }

--- a/packages/sdk-akamai/.env
+++ b/packages/sdk-akamai/.env
@@ -1,4 +1,4 @@
 # Used to identify the Edgeworker to be uploaded
 EDGEWORKER_ID=
 # Used to identify the Edgeworker version to be uploaded and activated by the NPM commands
-EDGEWORKER_VERSION=0.8
+EDGEWORKER_VERSION=0.16

--- a/packages/sdk-akamai/demo/bundle.json
+++ b/packages/sdk-akamai/demo/bundle.json
@@ -1,4 +1,4 @@
 {
-  "edgeworker-version": "0.8",
+  "edgeworker-version": "0.16",
   "description": "Target CDN Experimentation Akamai client Demo"
 }

--- a/packages/sdk-akamai/demo/index.js
+++ b/packages/sdk-akamai/demo/index.js
@@ -26,12 +26,13 @@ export async function responseProvider(request) {
     // retrieve the ECID and locationHintId; both values have to be persisted in the browser across requests
     // ECID - identifies each unique visitor with an unique id
     // locationHintId - the locationHintId is used to route the request to the closest Edge Node
-    const { ecid, locationHintId } = getPersistedValues(sdkResponse);
+    const { ecid, locationHintId, identityCookieValue } = getPersistedValues(sdkResponse);
 
     const response = `
     <script>
       document.cookie = "ECID=${ecid}; path=/";
       document.cookie = "kndctr_${CONFIG.orgId.replace("@", "_")}_cluster=${locationHintId}; path=/";
+      document.cookie = "kndctr_${CONFIG.orgId.replace("@", "_")}_identity=${identityCookieValue}; path=/";
     </script>
     <pre>${JSON.stringify(alloyEvent, " ", 2)}</pre>
     <pre>${JSON.stringify(sdkResponse, " ", 2)}</pre>

--- a/packages/sdk-akamai/demo/utils.js
+++ b/packages/sdk-akamai/demo/utils.js
@@ -52,12 +52,10 @@ const createClientRequest = (req, config) => {
       sendDisplayEvent: true,
     },
     xdm: {
+      ...(identityMap && { identityMap }),
       web: {
         webPageDetails: { URL: `${req.scheme}://${req.host}${req.url}` },
         webReferrer: { URL: "" },
-      },
-      identityMap: {
-        ...identityMap,
       },
       implementationDetails: {
         name: "server-side",
@@ -118,8 +116,15 @@ const getPersistedValues = (response) => {
   const locationHintId =
     locationHintIdHandle?.payload.find((scope) => scope.scope === "EdgeNetwork")
       ?.hint || "";
+  
+  const identityCookieValueHandle = response?.handle?.find(
+    (payload) =>
+      payload.type === "state:store"
+  );
+  const identityCookieValue = identityCookieValueHandle?.payload.find((entry) => entry.key.includes("_identity"))?.value || "";
 
-  return { ecid, locationHintId };
+
+  return { ecid, locationHintId, identityCookieValue };
 };
 
 export { createClientRequest, getPersistedValues };

--- a/packages/sdk-nodejs/demo/server.js
+++ b/packages/sdk-nodejs/demo/server.js
@@ -24,12 +24,14 @@ const handleGET = async (req, res) => {
     // retrieve the ECID and locationHintId; both values have to be persisted in the browser across requests
     // ECID - identifies each unique visitor with an unique id
     // locationHintId - the locationHintId is used to route the request to the closest Edge Node
-    const { ecid, locationHintId } = getPersistedValues(sdkResponse);
+    const { ecid, locationHintId, identityCookieValue } = getPersistedValues(sdkResponse);
 
     const clusterCookieName = `kndctr_${config.orgId.replace("@", "_")}_cluster`;
+    const identityCookieName = `kndctr_${config.orgId.replace("@", "_")}_identity`;
     res.setHeader("Set-Cookie", [
       `ECID=${ecid};`,
       `${clusterCookieName}=${locationHintId};`,
+      `${identityCookieName}=${identityCookieValue};`,
     ]);
     res.setHeader("Content-Type", "application/json");
     res.end(JSON.stringify({ sdkResponse }, null, 2));

--- a/packages/sdk-nodejs/demo/utils.js
+++ b/packages/sdk-nodejs/demo/utils.js
@@ -115,7 +115,13 @@ const getPersistedValues = (response) => {
     locationHintIdHandle?.payload.find((scope) => scope.scope === "EdgeNetwork")
       ?.hint || "";
 
-  return { ecid, locationHintId };
+  const identityCookieValueHandle = response?.handle?.find(
+    (payload) =>
+      payload.type === "state:store"
+  );
+  const identityCookieValue = identityCookieValueHandle?.payload.find((entry) => entry.key.includes("_identity"))?.value || "";
+
+  return { ecid, locationHintId, identityCookieValue };
 };
 
 export { createClientRequest, getPersistedValues };

--- a/packages/sdk/src/sendEvent.js
+++ b/packages/sdk/src/sendEvent.js
@@ -18,6 +18,12 @@ import { MESSAGES } from "./messages.js";
 import { RuleEngine } from "./ruleEngine.js";
 import { createUrlContext, createTimingContext } from "./contextProvider.js";
 import { getAepEdgeClusterCookie } from "./utils/cookie.js";
+import { createIdentityCookieValue } from "./utils/encodeIdentityCookie.js";
+import {
+  getIdentityCookieName,
+  getClusterCookieName,
+} from "./utils/getCookieName.js";
+import { getEcidFromStateEntries } from "./utils/decodeIdentityCookie.js";
 
 const getRequestIdentity = (namespaceCode) => {
   return (event) => {
@@ -86,14 +92,35 @@ export const sendEvent = async (clientOptions, requestBody) => {
   const logAdapterInstance = Container().getInstance(TOKENS.LOGGER);
   const { orgId, locationHintId, locationHint, stateStore } = clientOptions;
   const requestEcid = getRequestEcidIdentity(requestBody);
+  const requestFpid = getRequestFpidIdentity(requestBody);
 
+  console.log("requestEcid", requestEcid);
   let ecid = requestEcid || [{ id: "" }];
+  let ecidSource = null; // Track how ECID was obtained
 
   if (!requestEcid) {
-    const requestFpid = getRequestFpidIdentity(requestBody);
-    ecid[0].id = requestFpid
-      ? generateEcidFromFpid(orgId, requestFpid[0].id)
-      : generateECID();
+    // Identity cookie is ONLY checked when identityMap has no ECID (matching Konductor logic)
+    const ecidFromCookie = getEcidFromStateEntries(
+      orgId,
+      requestBody?.meta?.state?.entries,
+    );
+
+    if (ecidFromCookie) {
+      // Use ECID from identity cookie
+      ecid[0].id = ecidFromCookie;
+      ecidSource = "RECEIVED_IN_REQUEST"; // From existing identity
+    } else if (requestFpid) {
+      // Generate from FPID
+      ecid[0].id = generateEcidFromFpid(orgId, requestFpid[0].id);
+      ecidSource = "FIRST_PARTY_ID";
+    } else {
+      // Generate new random ECID
+      ecid[0].id = generateECID();
+      ecidSource = "RANDOM";
+    }
+  } else {
+    // ECID was provided in identityMap
+    ecidSource = "RECEIVED_IN_REQUEST";
   }
 
   const event = addContext({
@@ -162,10 +189,82 @@ export const sendEvent = async (clientOptions, requestBody) => {
     handle.push(locationHint);
   }
 
-  if (stateStore) {
-    handle.push(stateStore);
+  // Build state:store payload following Konductor's logic
+  const identityCookieName = getIdentityCookieName(orgId);
+  const clusterCookieName = getClusterCookieName(orgId);
+  const ecidValue = event.xdm.identityMap.ECID[0].id;
+
+  // Find existing cookies in request
+  const existingIdentityCookie = requestBody?.meta?.state?.entries?.find(
+    (entry) => entry.key === identityCookieName,
+  );
+  const existingClusterCookie = requestBody?.meta?.state?.entries?.find(
+    (entry) => entry.key === clusterCookieName,
+  );
+
+  // Extract ECID from existing identity cookie if present
+  const ecidFromExistingIdentity = existingIdentityCookie
+    ? getEcidFromStateEntries(orgId, [existingIdentityCookie])
+    : null;
+
+  const stateStorePayload = [];
+
+  // 1. Identity Cookie Logic (matching Konductor's writeRequired + write methods)
+  if (existingIdentityCookie && ecidFromExistingIdentity === ecidValue) {
+    // ECID matches existing identity cookie - preserve it exactly to maintain metadata
+    // This matches Konductor's logic: stored.copy(ecid = value, writeTime = Instant.now())
+    stateStorePayload.push(existingIdentityCookie);
+  } else {
+    // Either no identity cookie exists, or ECID has changed - generate new identity cookie
+    // This matches Konductor's logic for creating new StoredIdentity with fresh metadata
+    const regionValue = locationHintId || existingClusterCookie?.value || "";
+    //Identity cookie format is base64-encoded protobuf 
+    //identity cookie will will contain ecid, metadata, and writeTime
+    const identityCookieValue = createIdentityCookieValue(ecidValue, {
+      isNew: ecidSource === "RANDOM", // Only true for newly generated ECIDs
+      region: regionValue.toUpperCase(), // Region must be uppercase to match Konductor (e.g., "IRL1" not "irl1")
+      source: ecidSource, // Track how ECID was obtained
+    });
+
+    stateStorePayload.push({
+      key: identityCookieName,
+      value: identityCookieValue,
+      maxAge: 34128000, // ~395 days in seconds
+    });
   }
-  
+
+  // 2. Cluster Cookie Logic
+  // Cluster should come from: existing cluster cookie > locationHintId > edgeClusterId
+  const clusterValue =
+    existingClusterCookie?.value || locationHintId || edgeClusterId;
+
+  if (clusterValue) {
+    stateStorePayload.push({
+      key: clusterCookieName,
+      value: clusterValue,
+      maxAge: 1800, // 30 minutes in seconds
+    });
+  }
+
+  // 3. Merge other stateStore entries (excluding identity & cluster which we've already handled)
+  // This is for any additional cookies from locationHintRequester
+  if (stateStore?.payload) {
+    stateStore.payload.forEach((entry) => {
+      if (
+        entry.key !== identityCookieName &&
+        entry.key !== clusterCookieName
+      ) {
+        stateStorePayload.push(entry);
+      }
+    });
+  }
+
+  // Add state:store handle
+  handle.push({
+    type: "state:store",
+    payload: stateStorePayload,
+  });
+
   return {
     requestId: uuid(),
     handle,

--- a/packages/sdk/src/sendEvent.js
+++ b/packages/sdk/src/sendEvent.js
@@ -96,12 +96,16 @@ export const sendEvent = async (clientOptions, requestBody) => {
   const { orgId, locationHintId, locationHint, stateStore } = clientOptions;
   const requestEcid = getRequestEcidIdentity(requestBody);
   const requestFpid = getRequestFpidIdentity(requestBody);
+  const hasValidRequestEcid =
+    requestEcid &&
+    requestEcid.length > 0 &&
+    typeof requestEcid[0]?.id === "string" &&
+    requestEcid[0].id.trim() !== "";
 
-  console.log("requestEcid", requestEcid);
-  let ecid = requestEcid || [{ id: "" }];
+  let ecid = hasValidRequestEcid ? requestEcid : [{ id: "" }];
   let ecidSource = null; // Track how ECID was obtained
 
-  if (!requestEcid) {
+  if (!hasValidRequestEcid) {
     // Identity cookie is ONLY checked when identityMap has no ECID (matching Konductor logic)
     const ecidFromCookie = getEcidFromStateEntries(
       orgId,

--- a/packages/sdk/src/sendEvent.js
+++ b/packages/sdk/src/sendEvent.js
@@ -23,7 +23,10 @@ import {
   getIdentityCookieName,
   getClusterCookieName,
 } from "./utils/getCookieName.js";
-import { getEcidFromStateEntries } from "./utils/decodeIdentityCookie.js";
+import {
+  getEcidFromStateEntries,
+  extractFullIdentityFromIdentityCookie,
+} from "./utils/decodeIdentityCookie.js";
 
 const getRequestIdentity = (namespaceCode) => {
   return (event) => {
@@ -210,10 +213,34 @@ export const sendEvent = async (clientOptions, requestBody) => {
   const stateStorePayload = [];
 
   // 1. Identity Cookie Logic (matching Konductor's writeRequired + write methods)
+  const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
   if (existingIdentityCookie && ecidFromExistingIdentity === ecidValue) {
-    // ECID matches existing identity cookie - preserve it exactly to maintain metadata
-    // This matches Konductor's logic: stored.copy(ecid = value, writeTime = Instant.now())
-    stateStorePayload.push(existingIdentityCookie);
+    // ECID matches existing identity cookie - preserve or refresh based on write time
+    const fullIdentity = extractFullIdentityFromIdentityCookie(
+      existingIdentityCookie.value,
+    );
+    const writeTimeMs = fullIdentity?.write_time ?? 0;
+    const isWriteTimeOlderThan24h =
+      typeof writeTimeMs === "number" &&
+      Date.now() - writeTimeMs > TWENTY_FOUR_HOURS_MS;
+
+    if (isWriteTimeOlderThan24h) {
+      // Refresh cookie metadata and write time, keep ECID the same
+      const regionValue = locationHintId || existingClusterCookie?.value || "";
+      const identityCookieValue = createIdentityCookieValue(ecidValue, {
+        isNew: false,
+        region: regionValue.toUpperCase(),
+        source: ecidSource,
+      });
+      stateStorePayload.push({
+        key: identityCookieName,
+        value: identityCookieValue,
+        maxAge: 34128000,
+      });
+    } else {
+      stateStorePayload.push(existingIdentityCookie);
+    }
   } else {
     // Either no identity cookie exists, or ECID has changed - generate new identity cookie
     // This matches Konductor's logic for creating new StoredIdentity with fresh metadata

--- a/packages/sdk/src/utils/base64.js
+++ b/packages/sdk/src/utils/base64.js
@@ -1,0 +1,119 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/**
+ * Base64 encoding/decoding implementation that works in any JavaScript environment
+ * including Akamai EdgeWorkers (no btoa/atob/Buffer required)
+ */
+
+const BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/**
+ * Converts a byte array to a base64 string.
+ * Pure JavaScript implementation - works in EdgeWorkers, Node.js, and browsers.
+ * Uses URL-safe base64 encoding (RFC 4648 §5) without padding.
+ *
+ * @param {number[] | Uint8Array} bytes - The bytes to encode
+ * @returns {string} URL-safe base64 encoded string
+ */
+export const bytesToBase64 = (bytes) => {
+  // Convert to Uint8Array if needed
+  const uint8Array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  
+  let result = "";
+  let i = 0;
+  
+  // Process 3 bytes at a time
+  while (i < uint8Array.length) {
+    const byte1 = uint8Array[i++];
+    const byte2 = i < uint8Array.length ? uint8Array[i++] : 0;
+    const byte3 = i < uint8Array.length ? uint8Array[i++] : 0;
+    
+    // Convert 3 bytes (24 bits) into 4 base64 characters (6 bits each)
+    const bits = (byte1 << 16) | (byte2 << 8) | byte3;
+    
+    result += BASE64_CHARS.charAt((bits >> 18) & 0x3f);
+    result += BASE64_CHARS.charAt((bits >> 12) & 0x3f);
+    result += BASE64_CHARS.charAt((bits >> 6) & 0x3f);
+    result += BASE64_CHARS.charAt(bits & 0x3f);
+  }
+  
+  // Handle padding for standard base64
+  const paddingLength = (3 - (uint8Array.length % 3)) % 3;
+  if (paddingLength > 0) {
+    // Remove the extra characters that were added for padding
+    result = result.slice(0, -paddingLength);
+    // Note: We'll remove padding entirely for URL-safe base64 below
+  }
+  
+  // Convert to URL-safe base64 (replace + with -, / with _, remove padding =)
+  return result.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+};
+
+/**
+ * Converts a base64 string to a byte array.
+ * Pure JavaScript implementation - works in EdgeWorkers, Node.js, and browsers.
+ * Handles URL-safe base64 encoding.
+ *
+ * @param {string} base64String - The base64 string to decode
+ * @returns {Uint8Array} The decoded bytes
+ */
+export const base64ToBytes = (base64String) => {
+  // Convert URL-safe base64 to regular base64
+  let base64 = base64String.replace(/-/g, "+").replace(/_/g, "/");
+  
+  // Add padding if needed
+  const padding = (4 - (base64.length % 4)) % 4;
+  base64 += "=".repeat(padding);
+  
+  // Create lookup table for base64 characters
+  const lookup = {};
+  for (let i = 0; i < BASE64_CHARS.length; i++) {
+    lookup[BASE64_CHARS.charAt(i)] = i;
+  }
+  
+  const bytes = [];
+  let i = 0;
+  
+  // Process 4 base64 characters at a time
+  while (i < base64.length) {
+    const char1 = base64.charAt(i++);
+    const char2 = base64.charAt(i++);
+    const char3 = base64.charAt(i++);
+    const char4 = base64.charAt(i++);
+    
+    // Skip padding characters
+    if (char1 === "=" || char2 === "=") break;
+    
+    const bits1 = lookup[char1] || 0;
+    const bits2 = lookup[char2] || 0;
+    const bits3 = char3 !== "=" ? (lookup[char3] || 0) : 0;
+    const bits4 = char4 !== "=" ? (lookup[char4] || 0) : 0;
+    
+    // Convert 4 base64 characters (24 bits) into 3 bytes
+    const byte1 = (bits1 << 2) | (bits2 >> 4);
+    bytes.push(byte1);
+    
+    if (char3 !== "=") {
+      const byte2 = ((bits2 & 0x0f) << 4) | (bits3 >> 2);
+      bytes.push(byte2);
+    }
+    
+    if (char4 !== "=") {
+      const byte3 = ((bits3 & 0x03) << 6) | bits4;
+      bytes.push(byte3);
+    }
+  }
+  
+  return new Uint8Array(bytes);
+};
+

--- a/packages/sdk/src/utils/decodeIdentityCookie.js
+++ b/packages/sdk/src/utils/decodeIdentityCookie.js
@@ -1,0 +1,412 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/* eslint-disable no-bitwise */
+
+import { base64ToBytes } from "./base64.js";
+import { getIdentityCookieName } from "./getCookieName.js";
+
+const ECID_FIELD_NUMBER = 1;
+const METADATA_FIELD_NUMBER = 10;
+const WRITE_TIME_FIELD_NUMBER = 30;
+
+// Metadata field numbers
+const METADATA_FIELDS = {
+  CREATED_AT: 1,
+  IS_NEW: 2,
+  DEVICE_TYPE: 3,
+  REGION: 5,
+  SOURCE: 6,
+};
+
+const WIRE_TYPES = {
+  VARINT: 0,
+  I64: 1,
+  LEN: 2,
+  SGROUP: 3,
+  EGROUP: 4,
+  I32: 5,
+};
+
+/**
+ * Decodes a varint from a buffer starting at the given offset.
+ * Uses BigInt to avoid JavaScript's 32-bit bitwise operation limitation.
+ * @param {Uint8Array} buffer
+ * @param {number} offset
+ * @returns {{ value: number, length: number }}
+ */
+const decodeVarint = (buffer, offset) => {
+  let value = 0n; // Use BigInt to handle 64-bit integers
+  let length = 0;
+  let byte;
+  
+  do {
+    if (offset < 0 || offset + length >= buffer.length) {
+      throw new Error("Invalid varint: buffer ended unexpectedly");
+    }
+    byte = buffer[offset + length];
+    
+    // Use BigInt arithmetic to avoid 32-bit limitations
+    value |= BigInt(byte & 0x7f) << BigInt(7 * length);
+    
+    length += 1;
+    
+    if (length > 10) {
+      throw new Error("Invalid varint: too long");
+    }
+  } while (byte & 0x80);
+  
+  // Convert BigInt to Number (safe for timestamps which are within Number.MAX_SAFE_INTEGER)
+  return { value: Number(value), length };
+};
+
+/**
+ * Converts UTF-8 bytes to a string (EdgeWorker-compatible).
+ * @param {Uint8Array} bytes - The UTF-8 bytes to decode
+ * @returns {string} The decoded string
+ */
+const utf8BytesToString = (bytes) => {
+  let str = "";
+  let i = 0;
+  
+  while (i < bytes.length) {
+    const byte1 = bytes[i++];
+    
+    if (byte1 < 0x80) {
+      // 1-byte character
+      str += String.fromCharCode(byte1);
+    } else if ((byte1 & 0xe0) === 0xc0) {
+      // 2-byte character
+      const byte2 = bytes[i++];
+      str += String.fromCharCode(((byte1 & 0x1f) << 6) | (byte2 & 0x3f));
+    } else if ((byte1 & 0xf0) === 0xe0) {
+      // 3-byte character
+      const byte2 = bytes[i++];
+      const byte3 = bytes[i++];
+      str += String.fromCharCode(
+        ((byte1 & 0x0f) << 12) | ((byte2 & 0x3f) << 6) | (byte3 & 0x3f),
+      );
+    } else if ((byte1 & 0xf8) === 0xf0) {
+      // 4-byte character (surrogate pair)
+      const byte2 = bytes[i++];
+      const byte3 = bytes[i++];
+      const byte4 = bytes[i++];
+      let codePoint = ((byte1 & 0x07) << 18) | ((byte2 & 0x3f) << 12) |
+                      ((byte3 & 0x3f) << 6) | (byte4 & 0x3f);
+      codePoint -= 0x10000;
+      str += String.fromCharCode(0xd800 + (codePoint >> 10));
+      str += String.fromCharCode(0xdc00 + (codePoint & 0x3ff));
+    }
+  }
+  
+  return str;
+};
+
+/**
+ * Decodes a protobuf-encoded identity cookie to extract the ECID.
+ * @param {Uint8Array} buffer - The protobuf bytes
+ * @returns {string} The ECID value
+ */
+const decodeKndctrProtobuf = (buffer) => {
+  let offset = 0;
+  let ecid = null;
+
+  while (offset < buffer.length && !ecid) {
+    // Decode the tag
+    const { value: tag, length: tagLength } = decodeVarint(buffer, offset);
+    offset += tagLength;
+
+    // Extract wire type and field number
+    const wireType = tag & 0b111;
+    const fieldNumber = tag >> 3;
+
+    // Check if this is the ECID field
+    if (fieldNumber === ECID_FIELD_NUMBER) {
+      if (wireType === WIRE_TYPES.LEN) {
+        // Decode the length of the ECID string
+        const fieldValueLength = decodeVarint(buffer, offset);
+        offset += fieldValueLength.length;
+
+        // Decode the ECID as UTF-8 string (EdgeWorker-compatible)
+        ecid = utf8BytesToString(
+          buffer.slice(offset, offset + fieldValueLength.value),
+        );
+        return ecid;
+      }
+    } else {
+      // Skip fields we don't care about
+      switch (wireType) {
+        case WIRE_TYPES.VARINT:
+          offset += decodeVarint(buffer, offset).length;
+          break;
+        case WIRE_TYPES.I64:
+          offset += 8;
+          break;
+        case WIRE_TYPES.LEN: {
+          const fieldValueLength = decodeVarint(buffer, offset);
+          offset += fieldValueLength.length + fieldValueLength.value;
+          break;
+        }
+        case WIRE_TYPES.SGROUP:
+          break;
+        case WIRE_TYPES.EGROUP:
+          break;
+        case WIRE_TYPES.I32:
+          offset += 4;
+          break;
+        default:
+          throw new Error(
+            `Malformed kndctr cookie. Unknown wire type: ${wireType}`,
+          );
+      }
+    }
+  }
+
+  throw new Error("No ECID found in cookie.");
+};
+
+/**
+ * Decodes metadata from a protobuf message.
+ * @param {Uint8Array} buffer - The metadata protobuf bytes
+ * @returns {Object} The decoded metadata
+ */
+const decodeMetadata = (buffer) => {
+  const metadata = {};
+  let offset = 0;
+
+  while (offset < buffer.length) {
+    const { value: tag, length: tagLength } = decodeVarint(buffer, offset);
+    offset += tagLength;
+
+    const wireType = tag & 0b111;
+    const fieldNumber = tag >> 3;
+
+    switch (fieldNumber) {
+      case METADATA_FIELDS.CREATED_AT: {
+        // int64
+        const { value, length } = decodeVarint(buffer, offset);
+        metadata.created_at = value;
+        offset += length;
+        break;
+      }
+      case METADATA_FIELDS.IS_NEW: {
+        // bool
+        const { value, length } = decodeVarint(buffer, offset);
+        metadata.is_new = value !== 0;
+        offset += length;
+        break;
+      }
+      case METADATA_FIELDS.DEVICE_TYPE: {
+        // int32
+        const { value, length } = decodeVarint(buffer, offset);
+        metadata.device_type = value;
+        offset += length;
+        break;
+      }
+      case METADATA_FIELDS.REGION: {
+        // string
+        if (wireType === WIRE_TYPES.LEN) {
+          const { value: strLength, length: lenLength } = decodeVarint(buffer, offset);
+          offset += lenLength;
+          metadata.region = utf8BytesToString(
+            buffer.slice(offset, offset + strLength),
+          );
+          offset += strLength;
+        }
+        break;
+      }
+      case METADATA_FIELDS.SOURCE: {
+        // int32
+        const { value, length } = decodeVarint(buffer, offset);
+        metadata.source = value;
+        offset += length;
+        break;
+      }
+      default: {
+        // Skip unknown fields
+        switch (wireType) {
+          case WIRE_TYPES.VARINT:
+            offset += decodeVarint(buffer, offset).length;
+            break;
+          case WIRE_TYPES.I64:
+            offset += 8;
+            break;
+          case WIRE_TYPES.LEN: {
+            const { value: fieldLength, length: lenLength } = decodeVarint(buffer, offset);
+            offset += lenLength + fieldLength;
+            break;
+          }
+          case WIRE_TYPES.I32:
+            offset += 4;
+            break;
+          default:
+            throw new Error(`Unknown wire type in metadata: ${wireType}`);
+        }
+      }
+    }
+  }
+
+  return metadata;
+};
+
+/**
+ * Decodes a full identity cookie including ECID, metadata, and write time.
+ * @param {Uint8Array} buffer - The protobuf bytes
+ * @returns {Object} Object with ecid, metadata, and write_time
+ */
+const decodeFullIdentityProtobuf = (buffer) => {
+  const result = {
+    ecid: null,
+    metadata: null,
+    write_time: null,
+  };
+
+  let offset = 0;
+
+  while (offset < buffer.length) {
+    const { value: tag, length: tagLength } = decodeVarint(buffer, offset);
+    offset += tagLength;
+
+    const wireType = tag & 0b111;
+    const fieldNumber = tag >> 3;
+
+    switch (fieldNumber) {
+      case ECID_FIELD_NUMBER: {
+        // ECID (string)
+        if (wireType === WIRE_TYPES.LEN) {
+          const { value: fieldLength, length: lenLength } = decodeVarint(buffer, offset);
+          offset += lenLength;
+          result.ecid = utf8BytesToString(
+            buffer.slice(offset, offset + fieldLength),
+          );
+          offset += fieldLength;
+        }
+        break;
+      }
+      case METADATA_FIELD_NUMBER: {
+        // Metadata (message)
+        if (wireType === WIRE_TYPES.LEN) {
+          const { value: fieldLength, length: lenLength } = decodeVarint(buffer, offset);
+          offset += lenLength;
+          result.metadata = decodeMetadata(
+            buffer.slice(offset, offset + fieldLength),
+          );
+          offset += fieldLength;
+        }
+        break;
+      }
+      case WRITE_TIME_FIELD_NUMBER: {
+        // Write time (int64)
+        const { value, length } = decodeVarint(buffer, offset);
+        result.write_time = value;
+        offset += length;
+        break;
+      }
+      default: {
+        // Skip unknown fields
+        switch (wireType) {
+          case WIRE_TYPES.VARINT:
+            offset += decodeVarint(buffer, offset).length;
+            break;
+          case WIRE_TYPES.I64:
+            offset += 8;
+            break;
+          case WIRE_TYPES.LEN: {
+            const { value: fieldLength, length: lenLength } = decodeVarint(buffer, offset);
+            offset += lenLength + fieldLength;
+            break;
+          }
+          case WIRE_TYPES.I32:
+            offset += 4;
+            break;
+          default:
+            throw new Error(`Unknown wire type: ${wireType}`);
+        }
+      }
+    }
+  }
+
+  if (!result.ecid) {
+    throw new Error("No ECID found in cookie.");
+  }
+
+  return result;
+};
+
+/**
+ * Extracts ECID from a base64-encoded identity cookie value.
+ * @param {string} cookieValue - The base64-encoded identity cookie value
+ * @returns {string|null} The ECID, or null if decoding fails
+ */
+export const extractEcidFromIdentityCookie = (cookieValue) => {
+  try {
+    // Decode URL-safe base64 and parse protobuf
+    const decodedCookie = decodeURIComponent(cookieValue)
+      .replace(/_/g, "/")
+      .replace(/-/g, "+");
+
+    const cookieBytes = base64ToBytes(decodedCookie);
+    return decodeKndctrProtobuf(cookieBytes);
+  } catch (error) {
+    // If decoding fails, return null (cookie might be malformed)
+    return null;
+  }
+};
+
+/**
+ * Finds and extracts ECID from identity cookie in request meta state entries.
+ * @param {string} orgId - The organization ID
+ * @param {Array} stateEntries - The meta.state.entries array from the request
+ * @returns {string|null} The ECID, or null if not found or invalid
+ */
+export const getEcidFromStateEntries = (orgId, stateEntries) => {
+  if (!stateEntries || !Array.isArray(stateEntries)) {
+    return null;
+  }
+
+  // Build the identity cookie name
+  const identityCookieName = getIdentityCookieName(orgId);
+
+  // Find the identity cookie entry
+  const identityEntry = stateEntries.find(
+    (entry) => entry.key === identityCookieName,
+  );
+
+  if (!identityEntry || !identityEntry.value) {
+    return null;
+  }
+
+  // Extract and return the ECID
+  return extractEcidFromIdentityCookie(identityEntry.value);
+};
+
+/**
+ * Extracts full identity data (ECID, metadata, write_time) from a base64-encoded cookie.
+ * @param {string} cookieValue - The base64-encoded identity cookie value
+ * @returns {Object|null} Object with ecid, metadata, write_time, or null if decoding fails
+ */
+export const extractFullIdentityFromIdentityCookie = (cookieValue) => {
+  try {
+    // Decode URL-safe base64 and parse protobuf
+    const decodedCookie = decodeURIComponent(cookieValue)
+      .replace(/_/g, "/")
+      .replace(/-/g, "+");
+
+    const cookieBytes = base64ToBytes(decodedCookie);
+    return decodeFullIdentityProtobuf(cookieBytes);
+  } catch (error) {
+    // If decoding fails, return null (cookie might be malformed)
+    console.error("Failed to decode identity cookie:", error);
+    return null;
+  }
+};
+

--- a/packages/sdk/src/utils/encodeIdentityCookie.js
+++ b/packages/sdk/src/utils/encodeIdentityCookie.js
@@ -1,0 +1,177 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+  encodeString,
+  encodeInt64,
+  encodeInt32,
+  encodeBool,
+  encodeMessage,
+} from "./protobuf.js";
+import { bytesToBase64 } from "./base64.js";
+
+/**
+ * Protobuf field numbers for Identity message
+ * Based on the schema from Alloy:
+ * https://git.corp.adobe.com/experience-edge/konductor/blob/master/feature-identity/src/main/kotlin/com/adobe/edge/features/identity/data/StoredIdentity.kt
+ */
+const IDENTITY_FIELDS = {
+  ECID: 1,
+  METADATA: 10,
+  LAST_SYNC: 20,
+  SYNC_HASH: 21,
+  ID_SYNC_CONTAINER_ID: 22,
+  WRITE_TIME: 30,
+};
+
+/**
+ * Protobuf field numbers for IdentityMetadata message
+ */
+const METADATA_FIELDS = {
+  CREATED_AT: 1,
+  IS_NEW: 2,
+  DEVICE_TYPE: 3,
+  REGION: 5,
+  SOURCE: 6,
+};
+
+/**
+ * Device type enum values
+ */
+const DEVICE_TYPE = {
+  UNKNOWN: 0,
+  BROWSER: 1,
+  MOBILE: 2,
+};
+
+/**
+ * Source enum values
+ */
+const SOURCE = {
+  RANDOM: 0,
+  THIRD_PARTY_ID: 1,
+  FIRST_PARTY_ID: 2,
+  RECEIVED_IN_REQUEST: 3,
+};
+
+/**
+ * Encodes IdentityMetadata as a protobuf message.
+ *
+ * @param {Object} metadata - The metadata object
+ * @param {number} metadata.createdAt - UNIX timestamp when identity was created
+ * @param {boolean} metadata.isNew - Whether the identity is new
+ * @param {number} metadata.deviceType - Device type (0=UNKNOWN, 1=BROWSER, 2=MOBILE)
+ * @param {string} [metadata.region] - Edge region
+ * @param {number} metadata.source - Source of the identity (0=RANDOM, etc.)
+ * @returns {number[]} Encoded metadata bytes
+ */
+const encodeMetadata = (metadata) => {
+  const bytes = [];
+
+  // Field 1: created_at (int64)
+  if (metadata.createdAt !== undefined) {
+    bytes.push(...encodeInt64(METADATA_FIELDS.CREATED_AT, metadata.createdAt));
+  }
+
+  // Field 2: is_new (bool)
+  if (metadata.isNew !== undefined) {
+    bytes.push(...encodeBool(METADATA_FIELDS.IS_NEW, metadata.isNew));
+  }
+
+  // Field 3: device_type (int32)
+  if (metadata.deviceType !== undefined) {
+    bytes.push(...encodeInt32(METADATA_FIELDS.DEVICE_TYPE, metadata.deviceType));
+  }
+
+  // Field 5: region (string)
+  if (metadata.region) {
+    bytes.push(...encodeString(METADATA_FIELDS.REGION, metadata.region));
+  }
+
+  // Field 6: source (int32)
+  if (metadata.source !== undefined) {
+    bytes.push(...encodeInt32(METADATA_FIELDS.SOURCE, metadata.source));
+  }
+
+  return bytes;
+};
+
+/**
+ * Encodes an Identity protobuf message.
+ *
+ * @param {string} ecid - The ECID value
+ * @param {Object} [options] - Optional parameters
+ * @param {Object} [options.metadata] - Identity metadata
+ * @param {number} [options.writeTime] - UNIX timestamp when identity was written
+ * @returns {number[]} Encoded identity bytes
+ */
+export const encodeIdentityProtobuf = (ecid, options = {}) => {
+  const bytes = [];
+
+  // Field 1: ecid (string) - Required
+  bytes.push(...encodeString(IDENTITY_FIELDS.ECID, ecid));
+
+  // Field 10: metadata (message) - Optional
+  if (options.metadata) {
+    const metadataBytes = encodeMetadata(options.metadata);
+    if (metadataBytes.length > 0) {
+      bytes.push(...encodeMessage(IDENTITY_FIELDS.METADATA, metadataBytes));
+    }
+  }
+
+  // Field 30: write_time (int64) - Optional
+  if (options.writeTime !== undefined) {
+    bytes.push(...encodeInt64(IDENTITY_FIELDS.WRITE_TIME, options.writeTime));
+  }
+
+  return bytes;
+};
+
+/**
+ * Creates an identity cookie value (base64-encoded protobuf).
+ *
+ * @param {string} ecid - The ECID value
+ * @param {Object} [options] - Optional parameters
+ * @param {boolean} [options.isNew] - Whether the identity is new (default: true)
+ * @param {string} [options.region] - Edge region
+ * @param {string} [options.source] - Source of the ECID (e.g., "RANDOM", "FIRST_PARTY_ID", "RECEIVED_IN_REQUEST")
+ * @returns {string} Base64-encoded identity cookie value
+ */
+export const createIdentityCookieValue = (ecid, options = {}) => {
+  // Use milliseconds to match Konductor's UnixTimestampSerializer
+  const currentTimestamp = Date.now(); // milliseconds since epoch
+
+  // Map source string to SOURCE enum value
+  let sourceValue = SOURCE.RANDOM; // Default
+  if (options.source) {
+    sourceValue = SOURCE[options.source] !== undefined
+      ? SOURCE[options.source]
+      : SOURCE.RANDOM;
+  }
+  //This is metadata format which we follow from alloy
+  const metadata = {
+    createdAt: currentTimestamp,
+    isNew: options.isNew !== undefined ? options.isNew : true,
+    deviceType: DEVICE_TYPE.UNKNOWN, // Server-side, so unknown
+    source: sourceValue,
+    region: options.region || "",
+  };
+
+  const identityBytes = encodeIdentityProtobuf(ecid, {
+    metadata,
+    writeTime: currentTimestamp,
+  });
+
+  return bytesToBase64(identityBytes);
+};
+
+export { DEVICE_TYPE, SOURCE };

--- a/packages/sdk/src/utils/getCookieName.js
+++ b/packages/sdk/src/utils/getCookieName.js
@@ -1,0 +1,59 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const COOKIE_NAME_PREFIX = "kndctr";
+
+/**
+ * Sanitizes the organization ID for use in cookie names.
+ * Replaces @ with _ to create a valid cookie name.
+ *
+ * @param {string} orgId - The organization ID (e.g., "ABC123@AdobeOrg")
+ * @returns {string} Sanitized org ID (e.g., "ABC123_AdobeOrg")
+ */
+const sanitizeOrgId = (orgId) => {
+  return orgId.replace("@", "_");
+};
+
+/**
+ * Gets the namespaced cookie name for a given organization and key.
+ * Format: kndctr_<SANITIZED_ORGID>_<KEY>
+ *
+ * @param {string} orgId - The organization ID
+ * @param {string} key - The cookie key (e.g., "identity", "cluster")
+ * @returns {string} The full cookie name
+ */
+export const getCookieName = (orgId, key) => {
+  return `${COOKIE_NAME_PREFIX}_${sanitizeOrgId(orgId)}_${key}`;
+};
+
+/**
+ * Gets the identity cookie name for a given organization.
+ * Format: kndctr_<SANITIZED_ORGID>_identity
+ *
+ * @param {string} orgId - The organization ID
+ * @returns {string} The identity cookie name
+ */
+export const getIdentityCookieName = (orgId) => {
+  return getCookieName(orgId, "identity");
+};
+
+/**
+ * Gets the cluster cookie name for a given organization.
+ * Format: kndctr_<SANITIZED_ORGID>_cluster
+ *
+ * @param {string} orgId - The organization ID
+ * @returns {string} The cluster cookie name
+ */
+export const getClusterCookieName = (orgId) => {
+  return getCookieName(orgId, "cluster");
+};
+

--- a/packages/sdk/src/utils/protobuf.js
+++ b/packages/sdk/src/utils/protobuf.js
@@ -1,0 +1,218 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/* eslint-disable no-bitwise */
+
+/**
+ * Protobuf encoding utilities for creating identity cookies.
+ * Based on the protobuf wire format: https://protobuf.dev/programming-guides/encoding/
+ */
+
+/**
+ * Wire types used in protobuf encoding
+ * | ID | Name   | Used for                                                 |
+ * |----|--------|----------------------------------------------------------|
+ * | 0  | varint | int32, int64, uint32, uint64, sint32, sint64, bool, enum |
+ * | 2  | LEN    | string, bytes                                            |
+ */
+const WIRE_TYPES = {
+  VARINT: 0,
+  LEN: 2,
+};
+
+/**
+ * Encodes a number as a varint (variable-length integer).
+ * Uses BigInt to handle 64-bit integers correctly.
+ * Variable-width integers use anywhere between one and ten bytes,
+ * with small values using fewer bytes.
+ *
+ * Each byte in the varint has a continuation bit that indicates if the byte
+ * that follows it is part of the varint. This is the most significant bit (MSB).
+ * The lower 7 bits are a payload.
+ *
+ * @param {number} value - The number to encode
+ * @returns {number[]} Array of bytes representing the varint
+ */
+export const encodeVarint = (value) => {
+  const bytes = [];
+  let num = BigInt(value); // Convert to BigInt to handle 64-bit integers
+
+  while (num >= 0x80n) {
+    // Set the continuation bit (MSB) and add the lower 7 bits
+    bytes.push(Number(num & 0x7fn) | 0x80);
+    num >>= 7n; // BigInt right shift
+  }
+  // Add the final byte (no continuation bit)
+  bytes.push(Number(num & 0x7fn));
+
+  return bytes;
+};
+
+/**
+ * Creates a field tag by combining field number and wire type.
+ * Tag = (field_number << 3) | wire_type
+ *
+ * @param {number} fieldNumber - The field number from the protobuf schema
+ * @param {number} wireType - The wire type (VARINT or LEN)
+ * @returns {number[]} The encoded tag as varint bytes
+ */
+const encodeTag = (fieldNumber, wireType) => {
+  const tag = (fieldNumber << 3) | wireType;
+  return encodeVarint(tag);
+};
+
+/**
+ * Converts a string to UTF-8 bytes (EdgeWorker-compatible).
+ * @param {string} str - The string to encode
+ * @returns {number[]} Array of UTF-8 bytes
+ */
+const stringToUtf8Bytes = (str) => {
+  const bytes = [];
+  for (let i = 0; i < str.length; i++) {
+    let charCode = str.charCodeAt(i);
+    
+    if (charCode < 0x80) {
+      // 1-byte character (0xxxxxxx)
+      bytes.push(charCode);
+    } else if (charCode < 0x800) {
+      // 2-byte character (110xxxxx 10xxxxxx)
+      bytes.push(0xc0 | (charCode >> 6));
+      bytes.push(0x80 | (charCode & 0x3f));
+    } else if (charCode < 0xd800 || charCode >= 0xe000) {
+      // 3-byte character (1110xxxx 10xxxxxx 10xxxxxx)
+      bytes.push(0xe0 | (charCode >> 12));
+      bytes.push(0x80 | ((charCode >> 6) & 0x3f));
+      bytes.push(0x80 | (charCode & 0x3f));
+    } else {
+      // 4-byte character (surrogate pair)
+      i++;
+      const nextCharCode = str.charCodeAt(i);
+      charCode = 0x10000 + (((charCode & 0x3ff) << 10) | (nextCharCode & 0x3ff));
+      bytes.push(0xf0 | (charCode >> 18));
+      bytes.push(0x80 | ((charCode >> 12) & 0x3f));
+      bytes.push(0x80 | ((charCode >> 6) & 0x3f));
+      bytes.push(0x80 | (charCode & 0x3f));
+    }
+  }
+  return bytes;
+};
+
+/**
+ * Encodes a string field.
+ * Format: tag + length + UTF-8 bytes
+ *
+ * @param {number} fieldNumber - The field number
+ * @param {string} value - The string value to encode
+ * @returns {number[]} Array of bytes
+ */
+export const encodeString = (fieldNumber, value) => {
+  if (!value) return [];
+
+  const bytes = [];
+  const tag = encodeTag(fieldNumber, WIRE_TYPES.LEN);
+  bytes.push(...tag);
+
+  // Convert string to UTF-8 bytes (EdgeWorker-compatible)
+  const utf8Bytes = stringToUtf8Bytes(value);
+
+  // Add length and bytes
+  const length = encodeVarint(utf8Bytes.length);
+  bytes.push(...length);
+  bytes.push(...utf8Bytes);
+
+  return bytes;
+};
+
+/**
+ * Encodes an int64 field.
+ * Format: tag + varint value
+ *
+ * @param {number} fieldNumber - The field number
+ * @param {number} value - The integer value to encode
+ * @returns {number[]} Array of bytes
+ */
+export const encodeInt64 = (fieldNumber, value) => {
+  if (value === undefined || value === null) return [];
+
+  const bytes = [];
+  const tag = encodeTag(fieldNumber, WIRE_TYPES.VARINT);
+  bytes.push(...tag);
+
+  const valueBytes = encodeVarint(value);
+  bytes.push(...valueBytes);
+
+  return bytes;
+};
+
+/**
+ * Encodes an int32 field.
+ * Format: tag + varint value
+ *
+ * @param {number} fieldNumber - The field number
+ * @param {number} value - The integer value to encode
+ * @returns {number[]} Array of bytes
+ */
+export const encodeInt32 = (fieldNumber, value) => {
+  if (value === undefined || value === null) return [];
+
+  const bytes = [];
+  const tag = encodeTag(fieldNumber, WIRE_TYPES.VARINT);
+  bytes.push(...tag);
+
+  const valueBytes = encodeVarint(value);
+  bytes.push(...valueBytes);
+
+  return bytes;
+};
+
+/**
+ * Encodes a boolean field.
+ * Format: tag + varint (0 or 1)
+ *
+ * @param {number} fieldNumber - The field number
+ * @param {boolean} value - The boolean value to encode
+ * @returns {number[]} Array of bytes
+ */
+export const encodeBool = (fieldNumber, value) => {
+  if (value === undefined || value === null) return [];
+
+  const bytes = [];
+  const tag = encodeTag(fieldNumber, WIRE_TYPES.VARINT);
+  bytes.push(...tag);
+
+  bytes.push(value ? 1 : 0);
+
+  return bytes;
+};
+
+/**
+ * Encodes a nested message field.
+ * Format: tag + length + message bytes
+ *
+ * @param {number} fieldNumber - The field number
+ * @param {number[]} messageBytes - The encoded message bytes
+ * @returns {number[]} Array of bytes
+ */
+export const encodeMessage = (fieldNumber, messageBytes) => {
+  if (!messageBytes || messageBytes.length === 0) return [];
+
+  const bytes = [];
+  const tag = encodeTag(fieldNumber, WIRE_TYPES.LEN);
+  bytes.push(...tag);
+
+  const length = encodeVarint(messageBytes.length);
+  bytes.push(...length);
+  bytes.push(...messageBytes);
+
+  return bytes;
+};
+

--- a/packages/sdk/test/sendEvent.test.js
+++ b/packages/sdk/test/sendEvent.test.js
@@ -214,4 +214,262 @@ describe("sendEvent", () => {
     await sendEvent(clientOptions, requestBodyWithEcid);
     expect(logMock).toBeCalled();
   });
+
+  it("should include identity cookie in state:store when missing", async () => {
+    ruleEngineMock.mockReturnValue([]);
+    const request = await sendEvent(clientOptions, requestBodyWithEcid);
+
+    // Should have a state:store handle
+    const stateStoreHandle = request.handle.find(
+      (h) => h.type === "state:store",
+    );
+    expect(stateStoreHandle).toBeDefined();
+
+    // Should contain identity cookie
+    const identityCookie = stateStoreHandle.payload.find(
+      (entry) => entry.key === "kndctr_test-org-id_identity",
+    );
+    expect(identityCookie).toBeDefined();
+    expect(identityCookie.value).toBeTruthy();
+    expect(identityCookie.maxAge).toBe(34128000);
+  });
+
+  it("should not duplicate identity cookie if already present in stateStore", async () => {
+    ruleEngineMock.mockReturnValue([]);
+    const clientOptionsWithStateStore = {
+      ...clientOptions,
+      stateStore: {
+        type: "state:store",
+        payload: [
+          {
+            key: "kndctr_test-org-id_identity",
+            value: "existing-identity-cookie",
+            maxAge: 34128000,
+          },
+          {
+            key: "kndctr_test-org-id_cluster",
+            value: "or2",
+            maxAge: 1800,
+          },
+        ],
+      },
+    };
+
+    const request = await sendEvent(
+      clientOptionsWithStateStore,
+      requestBodyWithEcid,
+    );
+
+    // Should have a state:store handle
+    const stateStoreHandle = request.handle.find(
+      (h) => h.type === "state:store",
+    );
+    expect(stateStoreHandle).toBeDefined();
+
+    // Should have exactly 2 entries (not duplicated)
+    expect(stateStoreHandle.payload.length).toBe(2);
+
+    // Identity cookie should be the existing one
+    const identityCookie = stateStoreHandle.payload.find(
+      (entry) => entry.key === "kndctr_test-org-id_identity",
+    );
+    expect(identityCookie.value).toBe("existing-identity-cookie");
+  });
+
+  it("should add identity cookie to existing stateStore without identity", async () => {
+    ruleEngineMock.mockReturnValue([]);
+    const clientOptionsWithPartialStateStore = {
+      ...clientOptions,
+      stateStore: {
+        type: "state:store",
+        payload: [
+          {
+            key: "kndctr_test-org-id_cluster",
+            value: "or2",
+            maxAge: 1800,
+          },
+        ],
+      },
+    };
+
+    const request = await sendEvent(
+      clientOptionsWithPartialStateStore,
+      requestBodyWithEcid,
+    );
+
+    // Should have a state:store handle
+    const stateStoreHandle = request.handle.find(
+      (h) => h.type === "state:store",
+    );
+    expect(stateStoreHandle).toBeDefined();
+
+    // Should have 2 entries now (cluster + identity)
+    expect(stateStoreHandle.payload.length).toBe(2);
+
+    // Should have both cluster and identity
+    const clusterCookie = stateStoreHandle.payload.find(
+      (entry) => entry.key === "kndctr_test-org-id_cluster",
+    );
+    const identityCookie = stateStoreHandle.payload.find(
+      (entry) => entry.key === "kndctr_test-org-id_identity",
+    );
+
+    expect(clusterCookie).toBeDefined();
+    expect(identityCookie).toBeDefined();
+    expect(identityCookie.value).toBeTruthy();
+  });
+
+  it("should encode identity cookie in protobuf format", async () => {
+    ruleEngineMock.mockReturnValue([]);
+    const request = await sendEvent(clientOptions, requestBodyWithEcid);
+
+    const stateStoreHandle = request.handle.find(
+      (h) => h.type === "state:store",
+    );
+    const identityCookie = stateStoreHandle.payload.find(
+      (entry) => entry.key === "kndctr_test-org-id_identity",
+    );
+
+    // Should be a base64 string (URL-safe)
+    expect(typeof identityCookie.value).toBe("string");
+    expect(identityCookie.value).not.toContain("+");
+    expect(identityCookie.value).not.toContain("/");
+    expect(identityCookie.value).not.toContain("=");
+    expect(identityCookie.value.length).toBeGreaterThan(0);
+  });
+
+  it("should include locationHintId as region in identity cookie metadata", async () => {
+    ruleEngineMock.mockReturnValue([]);
+    const clientOptionsWithLocationHint = {
+      ...clientOptions,
+      locationHintId: "or2",
+    };
+
+    const request = await sendEvent(
+      clientOptionsWithLocationHint,
+      requestBodyWithEcid,
+    );
+
+    const stateStoreHandle = request.handle.find(
+      (h) => h.type === "state:store",
+    );
+    const identityCookie = stateStoreHandle.payload.find(
+      (entry) => entry.key === "kndctr_test-org-id_identity",
+    );
+
+    // Cookie should be created with the region
+    expect(identityCookie).toBeDefined();
+    expect(identityCookie.value).toBeTruthy();
+  });
+
+  it("should extract ECID from identity cookie in meta.state.entries when no ECID in identityMap", async () => {
+    ruleEngineMock.mockReturnValue([]);
+
+    // Create a valid identity cookie with a known ECID
+    const { createIdentityCookieValue } = await import(
+      "../src/utils/encodeIdentityCookie.js"
+    );
+    const knownEcid = "88888888888888888888";
+    const identityCookieValue = createIdentityCookieValue(knownEcid);
+
+    const requestBodyWithCookie = {
+      type: "decisioning.propositionFetch",
+      meta: {
+        state: {
+          entries: [
+            {
+              key: "kndctr_test-org-id_cluster",
+              value: "or2",
+            },
+            {
+              key: "kndctr_test-org-id_identity",
+              value: identityCookieValue,
+            },
+          ],
+        },
+      },
+      // No identityMap provided
+    };
+
+    const request = await sendEvent(clientOptions, requestBodyWithCookie);
+
+    // Should extract ECID from the identity cookie
+    const identityHandle = request.handle.find(
+      (h) => h.type === "identity:result",
+    );
+    expect(identityHandle).toBeDefined();
+    expect(identityHandle.payload[0].id).toBe(knownEcid);
+    expect(identityHandle.payload[0].namespace.code).toBe("ECID");
+  });
+
+  it("should prioritize ECID from identityMap over identity cookie", async () => {
+    ruleEngineMock.mockReturnValue([]);
+
+    const { createIdentityCookieValue } = await import(
+      "../src/utils/encodeIdentityCookie.js"
+    );
+    const cookieEcid = "11111111111111111111";
+    const requestEcid = "22222222222222222222";
+    const identityCookieValue = createIdentityCookieValue(cookieEcid);
+
+    const requestBodyWithBoth = {
+      type: "decisioning.propositionFetch",
+      xdm: {
+        identityMap: {
+          ECID: [
+            {
+              id: requestEcid,
+            },
+          ],
+        },
+      },
+      meta: {
+        state: {
+          entries: [
+            {
+              key: "kndctr_test-org-id_identity",
+              value: identityCookieValue,
+            },
+          ],
+        },
+      },
+    };
+
+    const request = await sendEvent(clientOptions, requestBodyWithBoth);
+
+    // Should use ECID from identityMap, not from cookie
+    const identityHandle = request.handle.find(
+      (h) => h.type === "identity:result",
+    );
+    expect(identityHandle.payload[0].id).toBe(requestEcid);
+  });
+
+  it("should fallback to generating ECID when identity cookie is malformed", async () => {
+    ruleEngineMock.mockReturnValue([]);
+
+    const requestBodyWithMalformedCookie = {
+      type: "decisioning.propositionFetch",
+      meta: {
+        state: {
+          entries: [
+            {
+              key: "kndctr_test-org-id_identity",
+              value: "malformed-invalid-cookie",
+            },
+          ],
+        },
+      },
+    };
+
+    const request = await sendEvent(
+      clientOptions,
+      requestBodyWithMalformedCookie,
+    );
+
+    // Should fallback to mocked-ecid (from generateECID mock)
+    const identityHandle = request.handle.find(
+      (h) => h.type === "identity:result",
+    );
+    expect(identityHandle.payload[0].id).toBe("mocked-ecid");
+  });
 });

--- a/packages/sdk/test/sendEvent.test.js
+++ b/packages/sdk/test/sendEvent.test.js
@@ -472,4 +472,120 @@ describe("sendEvent", () => {
     );
     expect(identityHandle.payload[0].id).toBe("mocked-ecid");
   });
+
+  it("should preserve existing identity cookie when ECID matches and write time is within 24h", async () => {
+    ruleEngineMock.mockReturnValue([]);
+
+    const { createIdentityCookieValue } = await import(
+      "../src/utils/encodeIdentityCookie.js"
+    );
+    const testEcid = "test-ecid";
+    const identityCookieValue = createIdentityCookieValue(testEcid, {
+      isNew: false,
+      region: "OR2",
+      source: "RECEIVED_IN_REQUEST",
+    });
+
+    const requestBodyWithRecentCookie = {
+      type: "decisioning.propositionFetch",
+      xdm: {
+        identityMap: {
+          ECID: [{ id: testEcid }],
+        },
+      },
+      meta: {
+        state: {
+          entries: [
+            {
+              key: "kndctr_test-org-id_identity",
+              value: identityCookieValue,
+            },
+          ],
+        },
+      },
+    };
+
+    const request = await sendEvent(
+      clientOptions,
+      requestBodyWithRecentCookie,
+    );
+
+    const stateStoreHandle = request.handle.find(
+      (h) => h.type === "state:store",
+    );
+    const identityEntry = stateStoreHandle.payload.find(
+      (e) => e.key === "kndctr_test-org-id_identity",
+    );
+    expect(identityEntry).toBeDefined();
+    expect(identityEntry.value).toBe(identityCookieValue);
+  });
+
+  it("should refresh identity cookie when ECID matches but write time is older than 24h", async () => {
+    ruleEngineMock.mockReturnValue([]);
+
+    const {
+      encodeIdentityProtobuf,
+      DEVICE_TYPE,
+      SOURCE,
+    } = await import("../src/utils/encodeIdentityCookie.js");
+    const { bytesToBase64 } = await import("../src/utils/base64.js");
+    const { extractFullIdentityFromIdentityCookie } = await import(
+      "../src/utils/decodeIdentityCookie.js"
+    );
+
+    const testEcid = "test-ecid";
+    const oldWriteTime = Date.now() - 25 * 60 * 60 * 1000;
+    const metadata = {
+      createdAt: oldWriteTime,
+      isNew: false,
+      deviceType: DEVICE_TYPE.UNKNOWN,
+      source: SOURCE.RECEIVED_IN_REQUEST,
+      region: "OR2",
+    };
+    const identityBytes = encodeIdentityProtobuf(testEcid, {
+      metadata,
+      writeTime: oldWriteTime,
+    });
+    const oldIdentityCookieValue = bytesToBase64(identityBytes);
+
+    const requestBodyWithOldCookie = {
+      type: "decisioning.propositionFetch",
+      xdm: {
+        identityMap: {
+          ECID: [{ id: testEcid }],
+        },
+      },
+      meta: {
+        state: {
+          entries: [
+            {
+              key: "kndctr_test-org-id_identity",
+              value: oldIdentityCookieValue,
+            },
+          ],
+        },
+      },
+    };
+
+    const request = await sendEvent(
+      clientOptions,
+      requestBodyWithOldCookie,
+    );
+
+    const stateStoreHandle = request.handle.find(
+      (h) => h.type === "state:store",
+    );
+    const identityEntry = stateStoreHandle.payload.find(
+      (e) => e.key === "kndctr_test-org-id_identity",
+    );
+    expect(identityEntry).toBeDefined();
+    expect(identityEntry.value).not.toBe(oldIdentityCookieValue);
+    expect(identityEntry.maxAge).toBe(34128000);
+
+    const refreshed = extractFullIdentityFromIdentityCookie(identityEntry.value);
+    expect(refreshed.ecid).toBe(testEcid);
+    expect(refreshed.write_time).toBeGreaterThanOrEqual(
+      Date.now() - 5000,
+    );
+  });
 });

--- a/packages/sdk/test/utils/base64.test.js
+++ b/packages/sdk/test/utils/base64.test.js
@@ -1,0 +1,81 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { describe, it, expect } from "@jest/globals";
+import { bytesToBase64, base64ToBytes } from "../../src/utils/base64.js";
+
+describe("base64 encoding", () => {
+  describe("bytesToBase64", () => {
+    it("should encode bytes to URL-safe base64", () => {
+      const bytes = [72, 101, 108, 108, 111]; // "Hello"
+      const result = bytesToBase64(bytes);
+      // Standard base64 would be "SGVsbG8="
+      // URL-safe removes padding: "SGVsbG8"
+      expect(result).toBe("SGVsbG8");
+    });
+
+    it("should handle Uint8Array input", () => {
+      const bytes = new Uint8Array([72, 101, 108, 108, 111]);
+      const result = bytesToBase64(bytes);
+      expect(result).toBe("SGVsbG8");
+    });
+
+    it("should replace + with - and / with _", () => {
+      // Create bytes that would produce + and / in standard base64
+      const bytes = [0xff, 0xff];
+      const result = bytesToBase64(bytes);
+      // Standard base64: "//8=" -> URL-safe: "__8"
+      expect(result).not.toContain("+");
+      expect(result).not.toContain("/");
+      expect(result).not.toContain("=");
+    });
+
+    it("should remove padding", () => {
+      const bytes = [72]; // "H"
+      const result = bytesToBase64(bytes);
+      // Standard base64 would be "SA=="
+      // URL-safe removes padding: "SA"
+      expect(result).toBe("SA");
+      expect(result).not.toContain("=");
+    });
+  });
+
+  describe("base64ToBytes", () => {
+    it("should decode URL-safe base64 to bytes", () => {
+      const base64 = "SGVsbG8";
+      const result = base64ToBytes(base64);
+      expect(Array.from(result)).toEqual([72, 101, 108, 108, 111]);
+    });
+
+    it("should handle base64 with - and _", () => {
+      const base64 = "__8";
+      const result = base64ToBytes(base64);
+      expect(Array.from(result)).toEqual([0xff, 0xff]);
+    });
+
+    it("should handle base64 without padding", () => {
+      const base64 = "SA";
+      const result = base64ToBytes(base64);
+      expect(Array.from(result)).toEqual([72]);
+    });
+  });
+
+  describe("round-trip encoding", () => {
+    it("should encode and decode correctly", () => {
+      const original = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+      const encoded = bytesToBase64(original);
+      const decoded = base64ToBytes(encoded);
+      expect(Array.from(decoded)).toEqual(original);
+    });
+  });
+});
+

--- a/packages/sdk/test/utils/decodeIdentityCookie.test.js
+++ b/packages/sdk/test/utils/decodeIdentityCookie.test.js
@@ -1,0 +1,197 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { describe, it, expect } from "@jest/globals";
+import {
+  extractEcidFromIdentityCookie,
+  getEcidFromStateEntries,
+} from "../../src/utils/decodeIdentityCookie.js";
+import { createIdentityCookieValue } from "../../src/utils/encodeIdentityCookie.js";
+
+describe("identity cookie decoding", () => {
+  describe("extractEcidFromIdentityCookie", () => {
+    it("should extract ECID from a valid identity cookie", () => {
+      const ecid = "12345678901234567890";
+      const cookieValue = createIdentityCookieValue(ecid);
+
+      const extractedEcid = extractEcidFromIdentityCookie(cookieValue);
+      expect(extractedEcid).toBe(ecid);
+    });
+
+    it("should extract ECID from a long ECID value", () => {
+      const ecid = "75142138344462263894507331812511658810";
+      const cookieValue = createIdentityCookieValue(ecid);
+
+      const extractedEcid = extractEcidFromIdentityCookie(cookieValue);
+      expect(extractedEcid).toBe(ecid);
+    });
+
+    it("should extract ECID with region metadata", () => {
+      const ecid = "98765432109876543210";
+      const cookieValue = createIdentityCookieValue(ecid, { region: "or2" });
+
+      const extractedEcid = extractEcidFromIdentityCookie(cookieValue);
+      expect(extractedEcid).toBe(ecid);
+    });
+
+    it("should return null for malformed cookie", () => {
+      const malformedCookie = "not-a-valid-base64-protobuf";
+      const extractedEcid = extractEcidFromIdentityCookie(malformedCookie);
+      expect(extractedEcid).toBeNull();
+    });
+
+    it("should return null for empty string", () => {
+      const extractedEcid = extractEcidFromIdentityCookie("");
+      expect(extractedEcid).toBeNull();
+    });
+
+    it("should handle URL-encoded cookie values", () => {
+      const ecid = "11111111111111111111";
+      const cookieValue = createIdentityCookieValue(ecid);
+      const urlEncodedValue = encodeURIComponent(cookieValue);
+
+      const extractedEcid = extractEcidFromIdentityCookie(urlEncodedValue);
+      expect(extractedEcid).toBe(ecid);
+    });
+
+    it("should round-trip encode and decode correctly", () => {
+      const testEcids = [
+        "12345",
+        "12345678901234567890",
+        "75142138344462263894507331812511658810",
+        "00000000000000000000",
+        "99999999999999999999",
+      ];
+
+      testEcids.forEach((ecid) => {
+        const encoded = createIdentityCookieValue(ecid);
+        const decoded = extractEcidFromIdentityCookie(encoded);
+        expect(decoded).toBe(ecid);
+      });
+    });
+  });
+
+  describe("getEcidFromStateEntries", () => {
+    const orgId = "TEST123@AdobeOrg";
+    const ecid = "12345678901234567890";
+
+    it("should extract ECID from state entries", () => {
+      const cookieValue = createIdentityCookieValue(ecid);
+      const stateEntries = [
+        {
+          key: "kndctr_TEST123_AdobeOrg_cluster",
+          value: "or2",
+        },
+        {
+          key: "kndctr_TEST123_AdobeOrg_identity",
+          value: cookieValue,
+        },
+      ];
+
+      const extractedEcid = getEcidFromStateEntries(orgId, stateEntries);
+      expect(extractedEcid).toBe(ecid);
+    });
+
+    it("should return null when state entries is null", () => {
+      const extractedEcid = getEcidFromStateEntries(orgId, null);
+      expect(extractedEcid).toBeNull();
+    });
+
+    it("should return null when state entries is undefined", () => {
+      const extractedEcid = getEcidFromStateEntries(orgId, undefined);
+      expect(extractedEcid).toBeNull();
+    });
+
+    it("should return null when state entries is not an array", () => {
+      const extractedEcid = getEcidFromStateEntries(orgId, {});
+      expect(extractedEcid).toBeNull();
+    });
+
+    it("should return null when identity cookie is not in entries", () => {
+      const stateEntries = [
+        {
+          key: "kndctr_TEST123_AdobeOrg_cluster",
+          value: "or2",
+        },
+      ];
+
+      const extractedEcid = getEcidFromStateEntries(orgId, stateEntries);
+      expect(extractedEcid).toBeNull();
+    });
+
+    it("should return null when identity cookie has no value", () => {
+      const stateEntries = [
+        {
+          key: "kndctr_TEST123_AdobeOrg_identity",
+          value: "",
+        },
+      ];
+
+      const extractedEcid = getEcidFromStateEntries(orgId, stateEntries);
+      expect(extractedEcid).toBeNull();
+    });
+
+    it("should return null when identity cookie is malformed", () => {
+      const stateEntries = [
+        {
+          key: "kndctr_TEST123_AdobeOrg_identity",
+          value: "malformed-cookie-value",
+        },
+      ];
+
+      const extractedEcid = getEcidFromStateEntries(orgId, stateEntries);
+      expect(extractedEcid).toBeNull();
+    });
+
+    it("should handle different org IDs correctly", () => {
+      const orgId2 = "DIFFERENT_ORG@AdobeOrg";
+      const ecid2 = "99999999999999999999";
+      const cookieValue = createIdentityCookieValue(ecid2);
+
+      const stateEntries = [
+        {
+          key: "kndctr_DIFFERENT_ORG_AdobeOrg_identity",
+          value: cookieValue,
+        },
+      ];
+
+      const extractedEcid = getEcidFromStateEntries(orgId2, stateEntries);
+      expect(extractedEcid).toBe(ecid2);
+    });
+
+    it("should extract ECID from entries with multiple cookies", () => {
+      const cookieValue = createIdentityCookieValue(ecid);
+      const stateEntries = [
+        {
+          key: "kndctr_TEST123_AdobeOrg_cluster",
+          value: "or2",
+        },
+        {
+          key: "kndctr_TEST123_AdobeOrg_consent",
+          value: "all",
+        },
+        {
+          key: "kndctr_TEST123_AdobeOrg_identity",
+          value: cookieValue,
+        },
+        {
+          key: "some_other_cookie",
+          value: "some_value",
+        },
+      ];
+
+      const extractedEcid = getEcidFromStateEntries(orgId, stateEntries);
+      expect(extractedEcid).toBe(ecid);
+    });
+  });
+});
+

--- a/packages/sdk/test/utils/encodeIdentityCookie.test.js
+++ b/packages/sdk/test/utils/encodeIdentityCookie.test.js
@@ -1,0 +1,162 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+import {
+  encodeIdentityProtobuf,
+  createIdentityCookieValue,
+} from "../../src/utils/encodeIdentityCookie.js";
+import { base64ToBytes } from "../../src/utils/base64.js";
+
+describe("identity cookie encoding", () => {
+  describe("encodeIdentityProtobuf", () => {
+    it("should encode ECID as field 1", () => {
+      const ecid = "12345678901234567890";
+      const result = encodeIdentityProtobuf(ecid);
+
+      // First byte should be tag for field 1, wire type 2 (LEN)
+      // (1 << 3) | 2 = 0x0a
+      expect(result[0]).toBe(0x0a);
+
+      // Second byte should be length of ECID
+      expect(result[1]).toBe(ecid.length);
+
+      // Should contain the ECID
+      expect(result.length).toBeGreaterThan(ecid.length);
+    });
+
+    it("should encode metadata when provided", () => {
+      const ecid = "12345678901234567890";
+      const metadata = {
+        createdAt: 1234567890,
+        isNew: true,
+        deviceType: 0,
+        source: 0,
+        region: "or2",
+      };
+
+      const result = encodeIdentityProtobuf(ecid, { metadata });
+
+      // Should be longer than just ECID encoding
+      expect(result.length).toBeGreaterThan(ecid.length + 2);
+
+      // Should contain metadata field tag (field 10, wire type 2)
+      // (10 << 3) | 2 = 82 = 0x52
+      expect(result).toContain(0x52);
+    });
+
+    it("should encode writeTime when provided", () => {
+      const ecid = "12345678901234567890";
+      const writeTime = 1234567890;
+
+      const result = encodeIdentityProtobuf(ecid, { writeTime });
+
+      // Should contain writeTime field tag (field 30, wire type 0)
+      // (30 << 3) | 0 = 240 = 0xF0
+      expect(result).toContain(0xf0);
+    });
+  });
+
+  describe("createIdentityCookieValue", () => {
+    beforeEach(() => {
+      // Mock Date.now() to return a fixed timestamp
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("should create a base64-encoded identity cookie", () => {
+      const ecid = "12345678901234567890";
+      const result = createIdentityCookieValue(ecid);
+
+      // Should be a non-empty string
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe("string");
+
+      // Should be URL-safe base64 (no +, /, or =)
+      expect(result).not.toContain("+");
+      expect(result).not.toContain("/");
+      expect(result).not.toContain("=");
+    });
+
+    it("should create a decodable protobuf message", () => {
+      const ecid = "12345678901234567890";
+      const result = createIdentityCookieValue(ecid);
+
+      // Decode the base64
+      const bytes = base64ToBytes(result);
+
+      // First field should be ECID (field 1, wire type 2)
+      expect(bytes[0]).toBe(0x0a);
+      expect(bytes[1]).toBe(ecid.length);
+    });
+
+    it("should include metadata by default", () => {
+      const ecid = "12345678901234567890";
+      const result = createIdentityCookieValue(ecid);
+
+      const bytes = base64ToBytes(result);
+
+      // Should contain metadata field (field 10, wire type 2 = 0x52)
+      expect(Array.from(bytes)).toContain(0x52);
+    });
+
+    it("should accept custom isNew flag", () => {
+      const ecid = "12345678901234567890";
+      const result = createIdentityCookieValue(ecid, { isNew: false });
+
+      // Should still be a valid base64 string
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe("string");
+    });
+
+    it("should accept custom region", () => {
+      const ecid = "12345678901234567890";
+      const result = createIdentityCookieValue(ecid, { region: "or2" });
+
+      const bytes = base64ToBytes(result);
+
+      // Should contain the region string "or2" somewhere in the bytes
+      const decoder = new TextDecoder();
+      const str = decoder.decode(bytes);
+      expect(str).toContain("or2");
+    });
+
+    it("should create different values for different ECIDs", () => {
+      const ecid1 = "11111111111111111111";
+      const ecid2 = "22222222222222222222";
+
+      const result1 = createIdentityCookieValue(ecid1);
+      const result2 = createIdentityCookieValue(ecid2);
+
+      expect(result1).not.toBe(result2);
+    });
+
+    it("should match expected format from Alloy examples", () => {
+      // This is a general format check, not an exact match
+      // since timestamps will differ
+      const ecid = "75142138344462263894507331812511658810";
+      const result = createIdentityCookieValue(ecid, { region: "OR2" });
+
+      // Should be a reasonably long base64 string
+      expect(result.length).toBeGreaterThan(50);
+
+      // Should start with the ECID field encoding
+      const bytes = base64ToBytes(result);
+      expect(bytes[0]).toBe(0x0a); // Field 1, wire type 2
+    });
+  });
+});
+

--- a/packages/sdk/test/utils/getCookieName.test.js
+++ b/packages/sdk/test/utils/getCookieName.test.js
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { describe, it, expect } from "@jest/globals";
+import {
+  getCookieName,
+  getIdentityCookieName,
+  getClusterCookieName,
+} from "../../src/utils/getCookieName.js";
+
+describe("cookie name helpers", () => {
+  describe("getCookieName", () => {
+    it("should create namespaced cookie name", () => {
+      const orgId = "ABC123@AdobeOrg";
+      const key = "identity";
+      const result = getCookieName(orgId, key);
+      expect(result).toBe("kndctr_ABC123_AdobeOrg_identity");
+    });
+
+    it("should replace @ with _", () => {
+      const orgId = "TEST@AdobeOrg";
+      const key = "test";
+      const result = getCookieName(orgId, key);
+      expect(result).not.toContain("@");
+      expect(result).toContain("_");
+    });
+
+    it("should use kndctr prefix", () => {
+      const orgId = "ABC@AdobeOrg";
+      const key = "cluster";
+      const result = getCookieName(orgId, key);
+      expect(result).toMatch(/^kndctr_/);
+    });
+  });
+
+  describe("getIdentityCookieName", () => {
+    it("should create identity cookie name", () => {
+      const orgId = "5BFE274A5F6980A50A495C08@AdobeOrg";
+      const result = getIdentityCookieName(orgId);
+      expect(result).toBe("kndctr_5BFE274A5F6980A50A495C08_AdobeOrg_identity");
+    });
+
+    it("should match Alloy format", () => {
+      const orgId = "ABC123@AdobeOrg";
+      const result = getIdentityCookieName(orgId);
+      expect(result).toBe("kndctr_ABC123_AdobeOrg_identity");
+    });
+  });
+
+  describe("getClusterCookieName", () => {
+    it("should create cluster cookie name", () => {
+      const orgId = "5BFE274A5F6980A50A495C08@AdobeOrg";
+      const result = getClusterCookieName(orgId);
+      expect(result).toBe("kndctr_5BFE274A5F6980A50A495C08_AdobeOrg_cluster");
+    });
+
+    it("should match Alloy format", () => {
+      const orgId = "ABC123@AdobeOrg";
+      const result = getClusterCookieName(orgId);
+      expect(result).toBe("kndctr_ABC123_AdobeOrg_cluster");
+    });
+  });
+});
+

--- a/packages/sdk/test/utils/protobuf.test.js
+++ b/packages/sdk/test/utils/protobuf.test.js
@@ -1,0 +1,121 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { describe, it, expect } from "@jest/globals";
+import {
+  encodeVarint,
+  encodeString,
+  encodeInt64,
+  encodeInt32,
+  encodeBool,
+} from "../../src/utils/protobuf.js";
+
+describe("protobuf encoding", () => {
+  describe("encodeVarint", () => {
+    it("should encode small values in a single byte", () => {
+      expect(encodeVarint(0)).toEqual([0]);
+      expect(encodeVarint(1)).toEqual([1]);
+      expect(encodeVarint(127)).toEqual([127]);
+    });
+
+    it("should encode larger values in multiple bytes", () => {
+      // 150 = 10010110 00000001 in varint encoding
+      expect(encodeVarint(150)).toEqual([0x96, 0x01]);
+    });
+
+    it("should encode 300", () => {
+      // 300 = 0xAC 0x02 in varint encoding
+      expect(encodeVarint(300)).toEqual([0xac, 0x02]);
+    });
+  });
+
+  describe("encodeString", () => {
+    it("should encode a string with tag and length", () => {
+      const result = encodeString(1, "test");
+      // Field 1, wire type 2 (LEN) = tag 0x0a
+      // Length 4
+      // UTF-8 bytes for "test"
+      expect(result).toEqual([0x0a, 0x04, 0x74, 0x65, 0x73, 0x74]);
+    });
+
+    it("should return empty array for empty string", () => {
+      expect(encodeString(1, "")).toEqual([]);
+    });
+
+    it("should return empty array for null", () => {
+      expect(encodeString(1, null)).toEqual([]);
+    });
+
+    it("should encode ECID correctly", () => {
+      const ecid = "12345678901234567890";
+      const result = encodeString(1, ecid);
+      // Tag for field 1, wire type 2
+      expect(result[0]).toBe(0x0a);
+      // Length should be 20
+      expect(result[1]).toBe(20);
+      // Should contain the ECID bytes
+      expect(result.length).toBe(2 + 20);
+    });
+  });
+
+  describe("encodeInt64", () => {
+    it("should encode an int64 with tag and varint value", () => {
+      const result = encodeInt64(30, 1234567890);
+      // Field 30, wire type 0 (VARINT) = tag 240 (0xF0)
+      expect(result[0]).toBe(240);
+      // Followed by varint encoding of 1234567890
+      expect(result.length).toBeGreaterThan(1);
+    });
+
+    it("should return empty array for null", () => {
+      expect(encodeInt64(1, null)).toEqual([]);
+    });
+
+    it("should return empty array for undefined", () => {
+      expect(encodeInt64(1, undefined)).toEqual([]);
+    });
+  });
+
+  describe("encodeInt32", () => {
+    it("should encode an int32 with tag and varint value", () => {
+      const result = encodeInt32(3, 1);
+      // Field 3, wire type 0 (VARINT) = tag 24 (0x18)
+      expect(result[0]).toBe(24);
+      expect(result[1]).toBe(1);
+    });
+
+    it("should return empty array for null", () => {
+      expect(encodeInt32(1, null)).toEqual([]);
+    });
+  });
+
+  describe("encodeBool", () => {
+    it("should encode true as 1", () => {
+      const result = encodeBool(2, true);
+      // Field 2, wire type 0 (VARINT) = tag 16 (0x10)
+      expect(result[0]).toBe(16);
+      expect(result[1]).toBe(1);
+    });
+
+    it("should encode false as 0", () => {
+      const result = encodeBool(2, false);
+      // Field 2, wire type 0 (VARINT) = tag 16 (0x10)
+      expect(result[0]).toBe(16);
+      expect(result[1]).toBe(0);
+    });
+
+    it("should return empty array for null", () => {
+      expect(encodeBool(1, null)).toEqual([]);
+    });
+  });
+});
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes a critical issue where the SDK was not including the ECID identity cookie in the `state:store` payload for first-time users. Previously, only the cluster cookie was returned, causing returning visitors to be treated as new users with duplicate ECIDs, breaking user persistence and tracking continuity.

**Key Changes:**
- Added identity cookie creation and inclusion in `state:store` payload
- Implemented proper ECID extraction from existing identity cookies
- Added identity cookie encoding/decoding utilities using protobuf format (matching Konductor/Alloy behavior)
- Updated demo utilities to extract and use cookies from `state:store` payload
- Ensured both cluster and identity cookies are preserved in `locationHintRequester`

The identity cookie is now properly created with:
- **Cookie name**: `kndctr_{orgId}_identity`
- **Cookie value**: Base64-encoded protobuf containing ECID, metadata, and writeTime
- **MaxAge**: 34128000 seconds (~395 days) for proper persistence

This ensures the SDK behavior matches the AEP API, where both cookies are returned in the `state:store` payload.

## Related Issue

This addresses a critical production-blocking issue for Home Depot's migration from AEP API to Akamai CDN SDK. The issue was that:
- First-time users only received the cluster cookie, not the identity cookie
- Returning visitors were treated as new users, generating duplicate ECIDs
- User persistence across sessions was broken
- Experimentation continuity and tracking data integrity were compromised

## Motivation and Context

**Business Impact:**
Home Depot experienced a critical issue after migrating from the AEP API to the Akamai CDN SDK for Adobe Target. The server-side response for first-time users was missing the identity cookie (`kndctr_{orgId}_identity`), which is required for proper user identification across sessions.

**Technical Context:**
- The AEP API returns both `kndctr_{orgId}_cluster` and `kndctr_{orgId}_identity` cookies in the `state:store` payload
- The SDK was only returning the cluster cookie
- Client integrations expect both cookies to be present
- Without the identity cookie, subsequent requests generate new ECIDs, leading to inconsistent user identification

**Solution:**
This PR implements the identity cookie creation logic that:
1. Creates identity cookies in the proper protobuf format (matching Konductor/Alloy)
2. Includes them in the `state:store` payload alongside cluster cookies
3. Properly extracts ECID from existing identity cookies to maintain user identity
4. Updates demo code to use cookies from `state:store` payload

## How Has This Been Tested?

**Unit Tests:**
- Added tests for identity cookie creation and encoding
- Added tests for ECID extraction from identity cookies
- Updated `sendEvent` tests to verify identity cookie inclusion in `state:store`
- All existing tests continue to pass

**Integration Testing:**
- Tested with Node.js demo server (`packages/sdk-nodejs/demo/server.js`)
- Verified HTTP response includes both cookies via `Set-Cookie` headers:
  ```
  Set-Cookie: kndctr_{orgId}_cluster=ind1; Path=/; Max-Age=1800
  Set-Cookie: kndctr_{orgId}_identity=CiY4OTA...; Path=/; Max-Age=34128000
  ```
- Verified `state:store` payload contains both cookies with correct structure
- Tested user persistence: second request with cookies returns the same ECID (not a new one)

**Test Environment:**
- Node.js 20+
- Tested with real Adobe Target datastream configuration
- Verified cookie encoding/decoding works correctly
- Confirmed behavior matches AEP API response format

**Manual Verification:**
```bash
# First request (new user)
curl http://127.0.0.1:3000/
# Response includes both cookies in state:store

# Second request (returning user) with cookies
curl -H "Cookie: kndctr_..._cluster=ind1; kndctr_..._identity=..." http://127.0.0.1:3000/
# Response uses the same ECID, proving persistence works
```

## Screenshots (if appropriate):

**Before Fix:**
```json
{
  "type": "state:store",
  "payload": [
    {
      "key": "kndctr_..._cluster",
      "value": "ind1",
      "maxAge": 1800
    }
    // ❌ Missing identity cookie
  ]
}
```

**After Fix:**
```json
{
  "type": "state:store",
  "payload": [
    {
      "key": "kndctr_..._identity",
      "value": "CiY4OTA...",
      "maxAge": 34128000
    },
    {
      "key": "kndctr_..._cluster",
      "value": "ind1",
      "maxAge": 1800
    }
  ]
}
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional Notes

**Files Changed:**
- `packages/sdk/src/sendEvent.js` - Added identity cookie creation and state:store payload building
- `packages/sdk/src/utils/encodeIdentityCookie.js` - Identity cookie protobuf encoding
- `packages/sdk/src/utils/decodeIdentityCookie.js` - Identity cookie decoding and ECID extraction
- `packages/sdk/src/utils/getCookieName.js` - Cookie name generation utilities
- `packages/sdk/src/locationHintRequester.js` - Preserve identity cookies in state:store
- `packages/sdk-nodejs/demo/utils.js` - Extract stateCookies from response
- `packages/sdk-nodejs/demo/server.js` - Use state:store cookies for Set-Cookie headers
- `packages/sdk-akamai/demo/utils.js` - Extract stateCookies from response
- `packages/sdk-akamai/demo/index.js` - Use state:store cookies for document.cookie

**Backwards Compatibility:**
- The changes are non-breaking - existing code continues to work
- Demo code includes fallback to legacy behavior if state:store is not available
- Identity cookie is only added when appropriate (matching Konductor logic)

**Performance Impact:**
- Minimal - identity cookie encoding/decoding is efficient
- No additional network requests required
- Cookie operations are synchronous and fast
